### PR TITLE
Fix subsection links capitalization

### DIFF
--- a/docs/customization/plant.mdx
+++ b/docs/customization/plant.mdx
@@ -25,7 +25,7 @@ data
 
 First, let's create a simple plant. Every plant requires the following fields:
 - `mods`: list of mods required to load this plant. **Currently not used**
-- `seeds`: list of items that can be used as a seed for this plant. Note that AgriCraft will always generate it's own seed for the plant. More information about adding seeds [can be found below](#Adding-seeds).
+- `seeds`: list of items that can be used as a seed for this plant. Note that AgriCraft will always generate it's own seed for the plant. More information about adding seeds [can be found below](#adding-seeds).
 - `stages`: list of growth stages for this plant. Every stage should be a number corresponding to the height of the plant in pixels.
 - `harvest_stage`: growth stage that the plant will have after it gets harvested.
 - `growth_chance`: chance the plant has of growing on a random tick.
@@ -33,7 +33,7 @@ First, let's create a simple plant. Every plant requires the following fields:
 - `cloneable`: determines if the plant can be cloned.
 - `spread_chance`: spread chance of the plant on clone.
 - `requirement`: an object containing plant's requirements:
-	- `soil_humidity`, `soil_acidity` and `soil_nutrients`: humidity, acidity and nutrients of the soil required for the plant to grow. An in-depth explanation [is provided below](#Specifying-soil-humidity-acidity-and-nutrients).
+	- `soil_humidity`, `soil_acidity` and `soil_nutrients`: humidity, acidity and nutrients of the soil required for the plant to grow. An in-depth explanation [is provided below](#specifying-soil-humidity-acidity-and-nutrients).
 	- `min_light`: minimum light required for the plant to grow.
 	- `max_light`: maximum light required for the plant to grow.
 	- `light_tolerance_factor`: light tolerance of the plant. For each level of plant strength, `min_light` decreases and `max_light` increases by the given value.

--- a/docs/customization/soil.md
+++ b/docs/customization/soil.md
@@ -9,9 +9,9 @@ Every soil requires the following fields:
 - `variants`: array of blocks representing this soil. Every soil object consists of:
 	-  `block`: tag or a resource location of the block.
 	-  `states`: list of states the block must match. *[optional]*
-- `humidity`: humidity condition of the soil. Accepted values [can be found here](#Humidity).
-- `acidity`: acidity condition of the soil. Accepted values [can be found here](#Acidity).
-- `nutrients`: nutrient condition of the soil. Accepted values [can be found here](#Nutrients).
+- `humidity`: humidity condition of the soil. Accepted values [can be found here](#humidity).
+- `acidity`: acidity condition of the soil. Accepted values [can be found here](#acidity).
+- `nutrients`: nutrient condition of the soil. Accepted values [can be found here](#nutrients).
 - `growth_modifier`: value used to modify the growth of the plants on this soil. The default value is `1.0`. Higher values will increase the growth speed, while lower ones will decrease it.
 
 The example below shows soul soil as a soil:

--- a/docs/customization/weed.md
+++ b/docs/customization/weed.md
@@ -13,8 +13,8 @@ Weed should have the following fields:
 - `growth_chance`: chance the weed has of growing on a random tick.
 - `aggressive`: if `true`, the weed will try to spread to adjacent crops when mature.
 - `lethal`: if `true`, the weed will try to kill the host plant when mature.
-- `rake_products`: list of possible raking products of the weed. Follows the same structure as [plant products](./plant.mdx#Adding-plant-products).
-- `requirement`: an object containing plant's requirements. Follows the same structure as plants, which is explained [here](./plant.mdx#Creating-a-simple-plant) and [here](./plant.mdx#Adding-additional-requirements).
+- `rake_products`: list of possible raking products of the weed. Follows the same structure as [plant products](./plant.mdx#adding-plant-products).
+- `requirement`: an object containing plant's requirements. Follows the same structure as plants, which is explained [here](./plant.mdx#creating-a-simple-plant) and [here](./plant.mdx#adding-additional-requirements).
 
 
 The example below shows a basic weed:
@@ -66,7 +66,7 @@ The example below shows a basic weed:
 
 ## Resourcepack
 
-The resourcepack part describes how the weed is rendered. It follows the same architecture as the [plant resourcepack part](./plant.mdx#Resourcepack).
+The resourcepack part describes how the weed is rendered. It follows the same architecture as the [plant resourcepack part](./plant.mdx#resourcepack).
 
 The only difference is that the models must be placed in the `weed` folder instead of `crop`.
 


### PR DESCRIPTION
All subsection links were made lowercase to make them work on the github.io page.